### PR TITLE
Переключение версии SDK на 19.320 в ветке rc-19.320

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 node ('controls') {
-def version = "19.310"
+def version = "19.320"
 def workspace = "/home/sbis/workspace/ui_${version}/${BRANCH_NAME}"
     ws (workspace){
         deleteDir()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "saby-ui",
-   "version": "19.310.0",
+   "version": "19.320.0",
    "repository": {
       "type": "git",
       "url": "git@platform-git.sbis.ru:saby/UI.git"
@@ -61,17 +61,17 @@
       "eslint": "^5.6.1",
       "express": "^4.16.3",
       "requirejs": "2.1.18",
-      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-19.310",
-      "Router": "git+https://github.com/saby/Router.git#rc-19.310",
+      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-19.320",
+      "Router": "git+https://github.com/saby/Router.git#rc-19.320",
       "saby-inferno": "git+https://github.com/saby/inferno.git#master",
-      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-19.310",
-      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-19.310",
-      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-19.310",
+      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-19.320",
+      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-19.320",
+      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-19.320",
       "serve-static": "1.11.x",
-      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-19.310",
-      "saby-units": "git+https://github.com/saby/Units.git#rc-19.310",
-      "saby-types": "git+https://github.com/saby/Types.git#rc-19.310",
-      "sbis-cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-19.310",
-      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-19.310"
+      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-19.320",
+      "saby-units": "git+https://github.com/saby/Units.git#rc-19.320",
+      "saby-types": "git+https://github.com/saby/Types.git#rc-19.320",
+      "sbis-cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-19.320",
+      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-19.320"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/4089/".