### PR TITLE
Переключение версии SDK на 19.510 в ветке rc-19.510

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ import java.time.*
 import java.lang.Math
 
 node ('controls') {
-def version = "19.500"
+def version = "19.510"
 def workspace = "/home/sbis/workspace/ui_${version}/${BRANCH_NAME}"
     ws (workspace){
         deleteDir()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "saby-ui",
-   "version": "19.500.0",
+   "version": "19.510.0",
    "repository": {
       "type": "git",
       "url": "git@platform-git.sbis.ru:saby/UI.git"
@@ -54,22 +54,22 @@
    "dependencies": {},
    "devDependencies": {
       "@tensor-corp/eslint-config": "^2.0.3",
-      "Router": "git+https://github.com/saby/Router.git#rc-19.500",
+      "Router": "git+https://github.com/saby/Router.git#rc-19.510",
       "body-parser": "^1.18.3",
-      "cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-19.500",
+      "cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-19.510",
       "cookie-parser": "^1.4.3",
       "eslint": "^5.6.1",
       "express": "^4.16.3",
       "requirejs": "2.1.18",
-      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-19.500",
-      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-19.500",
-      "saby-types": "git+https://github.com/saby/Types.git#rc-19.500",
-      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-19.500",
-      "saby-units": "git+https://github.com/saby/Units.git#rc-19.500",
-      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-19.500",
-      "sbis3-controls": "git+https://git.sbis.ru/sbis/controls.git#rc-19.500",
-      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-19.500",
+      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-19.510",
+      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-19.510",
+      "saby-types": "git+https://github.com/saby/Types.git#rc-19.510",
+      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-19.510",
+      "saby-units": "git+https://github.com/saby/Units.git#rc-19.510",
+      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-19.510",
+      "sbis3-controls": "git+https://git.sbis.ru/sbis/controls.git#rc-19.510",
+      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-19.510",
       "serve-static": "1.11.x",
-      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-19.500"
+      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-19.510"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/4526/".