### PR TITLE
Переключение версии SDK на 20.1100 в ветке rc-20.1100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "saby-ui",
-   "version": "20.1000.0",
+   "version": "20.1100.0",
    "repository": {
       "type": "git",
       "url": "git@platform-git.sbis.ru:saby/UI.git"
@@ -54,22 +54,22 @@
    "dependencies": {},
    "devDependencies": {
       "@tensor-corp/eslint-config": "^2.0.3",
-      "Router": "git+https://github.com/saby/Router.git#rc-20.1000",
+      "Router": "git+https://github.com/saby/Router.git#rc-20.1100",
       "body-parser": "^1.18.3",
-      "cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-20.1000",
+      "cdn": "git+https://github.com/saby/wasaby-cdn.git#rc-20.1100",
       "cookie-parser": "^1.4.3",
       "eslint": "^5.6.1",
       "express": "^4.16.3",
       "requirejs": "2.1.18",
-      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-20.1000",
-      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-20.1000",
-      "saby-types": "git+https://github.com/saby/Types.git#rc-20.1000",
-      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-20.1000",
-      "saby-units": "git+https://github.com/saby/Units.git#rc-20.1000",
-      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-20.1000",
-      "sbis3-controls": "git+https://git.sbis.ru/sbis/controls.git#rc-20.1000",
-      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-20.1000",
+      "rmi": "git+https://git.sbis.ru/sbis/rmi.git#rc-20.1100",
+      "saby-i18n": "git+https://github.com/saby/i18n.git#rc-20.1100",
+      "saby-types": "git+https://github.com/saby/Types.git#rc-20.1100",
+      "saby-typescript": "git+https://github.com/saby/TypeScript.git#rc-20.1100",
+      "saby-units": "git+https://github.com/saby/Units.git#rc-20.1100",
+      "sbis3-builder": "git+https://github.com/saby/Builder.git#rc-20.1100",
+      "sbis3-controls": "git+https://git.sbis.ru/sbis/controls.git#rc-20.1100",
+      "sbis3-ws": "git+https://git.sbis.ru/sbis/ws.git#rc-20.1100",
       "serve-static": "1.11.x",
-      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-20.1000"
+      "wasaby-app": "git+https://github.com/saby/wasaby-app.git#rc-20.1100"
    }
 }


### PR DESCRIPTION
Мерж создан сборкой "http://ci.sbis.ru/job/sdk_cheker/5963/".