### PR TITLE
Уточнён возвращаемый тип в хуке _beforeMount

### DIFF
--- a/UI/_base/Control.ts
+++ b/UI/_base/Control.ts
@@ -696,7 +696,7 @@ export default class Control<TOptions extends IControlOptions = {}, TState = voi
     * @see Documentation: Server render
     */
    protected _beforeMount(options?: TOptions, contexts?: object, receivedState?: TState): Promise<TState> |
-      Promise<void> | void {
+      Promise<void> | Promise<TState | void> | void {
       return undefined;
    }
 


### PR DESCRIPTION
При обработке полученного состояния от сервиса представления бывает, что всё равно необходимо вернуть Promise.
Чтобы принудительно не приводить возвращаемый Promise к "Promise<TState> | Promise<void>" уточнён возвращаемый тип метода